### PR TITLE
Add Github Actions CI, Small Build Fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-linux:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Init submodules
+      run: git submodule update --init --recursive
+    - name: Run build
+      run: cargo build
+
+
+  build-macos:
+
+    runs-on: macos-11
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Init submodules
+      run: git submodule update --init --recursive
+    - name: Run build
+      run: cargo build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
     - name: Run build
       run: cargo build
 
-
+  # MacOS Disabled for now, see issue #2
   build-macos:
-
+    if: ${{ false }}
     runs-on: macos-11
 
     steps:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Rust bindings for [USD](https://github.com/PixarAnimationStudios/USD).
 
+CI Status: ![CI](https://github.com/luke-titley/usd-rs/actions/workflows/ci.yml/badge.svg)
+
+
 # What works ?
 - You can create and open/save/export a stage.
 - You can define a prim and get/set attributes on it.

--- a/usd-cpp/Cargo.toml
+++ b/usd-cpp/Cargo.toml
@@ -16,6 +16,6 @@ exclude = [
 ]
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["rlib", "dylib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This adds a basic github actions CI (Macos currently disabled, given issue #2)
This also adds a small fix to usd-cpp's cargo proposed by @kubo-von 