### PR TITLE
build: Re-enable CI build for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,7 @@ jobs:
         name: docs
         path: docs
 
-  # MacOS Disabled for now, see issue #2
   build-macos:
-    if: ${{ false }}
     runs-on: macos-11
 
     steps:


### PR DESCRIPTION
It appears to be working now with recent updates / USD version.

Closes #2