### PR TITLE
Fix warnings in build scripts and examples

### DIFF
--- a/usd-examples/src/main.rs
+++ b/usd-examples/src/main.rs
@@ -8,6 +8,7 @@ use pxr::vt;
 
 use std::convert::TryFrom;
 
+#[allow(dead_code)]
 fn open_kitchen_set() -> pxr::NoResult {
     let stage = pxr::usd::Stage::open(pxr::usd::stage_desc::Open {
         file_path: "../assets/Kitchen_set/Kitchen_set.usd",
@@ -22,6 +23,7 @@ fn open_kitchen_set() -> pxr::NoResult {
     Ok(())
 }
 
+#[allow(dead_code)]
 fn add_references() -> pxr::NoResult {
     let asset_path = "asset.usda";
 
@@ -32,8 +34,8 @@ fn add_references() -> pxr::NoResult {
     stage.define_prim(
         &pxr::sdf::Path::try_from("/root").unwrap(),
         &pxr::tf::Token::default(),
-    );
-    stage.save();
+    )?;
+    stage.save()?;
 
     let stage = pxr::usd::Stage::create_new(pxr::usd::stage_desc::CreateNew {
         identifier: "scene.usda",
@@ -44,7 +46,7 @@ fn add_references() -> pxr::NoResult {
         .get_root_layer()
         .insert_sub_layer_path(asset_path, None)?;
 
-    stage.save();
+    stage.save()?;
 
     Ok(())
 }

--- a/usd-rs/build.rs
+++ b/usd-rs/build.rs
@@ -15,14 +15,11 @@ fn copy_headers(out_dir: &std::path::PathBuf) -> std::path::PathBuf {
     let mut include_dir = cpp_out_dir.clone();
     include_dir.push("include");
 
-    std::fs::create_dir_all(cpp_out_dir.clone());
+    std::fs::create_dir_all(cpp_out_dir.clone()).expect("cargo OUT_DIR should be writable");
     let mut options = fs_extra::dir::CopyOptions::default();
     options.overwrite = true;
     fs_extra::dir::copy(source_include_dir, cpp_out_dir.clone(), &options)
         .unwrap();
-
-    let lib = std::path::PathBuf::from("");
-    let lib_dir = std::path::PathBuf::from("");
 
     include_dir
 }


### PR DESCRIPTION
Some instances of unused `Result` values that we need to either propagate or unwrap/expect.

Also includes a few Clippy suggestions.

This leaves `cargo build` & `test` nice and tidy now, just one warning coming from the USD C++!