### PR TITLE
Add `PrimvarRef::set_interpolation`

### DIFF
--- a/usd-rs/src/pxr/usd_geom/primvar.rs
+++ b/usd-rs/src/pxr/usd_geom/primvar.rs
@@ -38,6 +38,14 @@ impl PrimvarRef {
             })
         }
     }
+
+    pub fn set_interpolation(&self, interpolation: &tf::Token) -> bool {
+        unsafe {
+            cpp!([self as "pxr::UsdGeomPrimvar*", interpolation as "const pxr::TfToken *"] -> bool as "bool" {
+                return self->SetInterpolation(*interpolation);
+            })
+        }
+    }
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Hi, not sure how active this project is, but I've recently been using it to convert a large number of dense voxel models to meshes and ran into the issue that I couldn't set the interpolation mode for vertex colours, so I've added that.

I'm also in the ASWF slack, happy to discuss things there as well.